### PR TITLE
Start a small module to talk with API

### DIFF
--- a/api/apiConfig.ts
+++ b/api/apiConfig.ts
@@ -1,4 +1,0 @@
-const BASE_URL: string = "https://en.wikipedia.org"
-const ENDPOINT: string = "/w/api.php?"
-
-export { BASE_URL, ENDPOINT }

--- a/api/apiConfig.ts
+++ b/api/apiConfig.ts
@@ -1,0 +1,4 @@
+const BASE_URL: string = "https://en.wikipedia.org"
+const ENDPOINT: string = "/w/api.php?"
+
+export { BASE_URL, ENDPOINT }

--- a/api/wikipediaSource.ts
+++ b/api/wikipediaSource.ts
@@ -36,6 +36,7 @@ async function fetchIntro(pageTitle: string): Promise<string> {
             }
             throw new Error(`Page with title ${pageTitle} was not found.`)
         })
+        .catch(error => console.error('Error fetching introduction of Wikipedia page : ', error))
 }
 
 /**
@@ -74,7 +75,8 @@ async function fetchImageUrl(pageTitle: string, thumbSize: number): Promise<stri
                }
            }
            throw new Error(`Image for page with title ${pageTitle} was not found.`)
-   });
+        })
+       .catch(error => console.error('Error fetching image URL of Wikipedia page : ', error))
 }
 
 export { fetchIntro, fetchImageUrl }

--- a/api/wikipediaSource.ts
+++ b/api/wikipediaSource.ts
@@ -1,30 +1,80 @@
-import {BASE_URL, ENDPOINT } from "~/api/apiConfig";
+const BASE_URL: string = "https://en.wikipedia.org"
+const ENDPOINT: string = "/w/api.php?"
+
 
 /**
- * Fetch and return the HTML of the given Wikipedia page.
+ * Fetch and return the introduction as plain text of the given Wikipedia page.
+ * Uses the MediaWiki Action API.
  * @param pageTitle the title of the Wikipedia page, must be first-capitalized
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
+ * @throws Error if no page corresponding to the given title is found
  */
-async function fetchHTMLPage(pageTitle: string): Promise<string> {
-    const searchParams = {
-        action: "parse",
+async function fetchIntro(pageTitle: string): Promise<string> {
+    const searchParams: Record<string, string> = {
+        action: "query",
+        titles: pageTitle,
         format: "json",
-        prop: "text",
-        page: pageTitle
+        prop: "extracts",
+        exintro: "true",
+        explaintext: "true",
+        origin: "*"
     }
 
-    const queryParams: URLSearchParams = new URLSearchParams(searchParams);
+    const queryParams: string = new URLSearchParams(searchParams).toString()
     const url: string = BASE_URL + ENDPOINT + queryParams
 
-    try {
-        const response: Response = await fetch(url);
-        const data = await response.json();
-        return data.parse.text
-    } catch (error) {
-        console.error('Error fetching page:', error);
-        throw error;
-    }
+    return fetch(url)
+        .then(response => response.json())
+        .then(data => {
+            if ('query' in data && 'pages' in data.query) {
+                const pages = data.query.pages
+                const pageIds: string[] = Object.keys(pages)
+                if (pageIds.length === 1 && pageIds[0] !== '-1') {
+                    const pageId: number = Number.parseInt(pageIds[0])
+                    return pages[pageId].extract
+                }
+            }
+            throw new Error(`Page with title ${pageTitle} was not found.`)
+        })
 }
 
+/**
+ * Fetch and return the source URL of the main picture of the given Wikipedia page.
+ * Uses the MediaWiki Action API.
+ * @param pageTitle the title of the Wikipedia page, must be first-capitalized
+ * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
+ * @param thumbSize the width in pixels of the wanted thumbnail
+ * @throws Error if no page corresponding to the given title is found
+ */
+async function fetchImageUrl(pageTitle: string, thumbSize: number): Promise<string> {
+    const searchParams: Record<string, string> = {
+        action: "query",
+        titles: pageTitle,
+        format: "json",
+        prop: "pageimages",
+        piprop: "thumbnail",
+        pithumbsize: thumbSize.toString(),
+        origin: "*",
+    };
 
-export { fetchHTMLPage }
+    const queryParams: string = new URLSearchParams(searchParams).toString()
+    const url: string = BASE_URL + ENDPOINT + queryParams
+
+   return fetch(url)
+       .then(response => response.json())
+       .then(data => {
+           if ('query' in data && 'pages' in data.query) {
+               const pages = data.query.pages
+               const pageIds: string[] = Object.keys(pages)
+               if (pageIds.length === 1 && pageIds[0] !== '-1') {
+                   const pageId: number = Number.parseInt(pageIds[0])
+                   if ('thumbnail' in pages[pageId]) {
+                       return pages[pageId].thumbnail.source
+                   }
+               }
+           }
+           throw new Error(`Image for page with title ${pageTitle} was not found.`)
+   });
+}
+
+export { fetchIntro, fetchImageUrl }

--- a/api/wikipediaSource.ts
+++ b/api/wikipediaSource.ts
@@ -11,7 +11,7 @@ const ENDPOINT: string = "/w/api.php?"
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
  * @return string
  */
-export async function fetchIntro(pageTitle: string): Promise<string> {
+export async function fetchIntro(pageTitle: string): Promise<any> {
     const searchParams: Record<string, string> = {
         action: "query",
         titles: pageTitle,
@@ -49,7 +49,7 @@ export async function fetchIntro(pageTitle: string): Promise<string> {
  * @param thumbSize the width in pixels of the wanted thumbnail
  * @return string
  */
-export async function fetchImageUrl(pageTitle: string, thumbSize: number): Promise<string> {
+export async function fetchImageUrl(pageTitle: string, thumbSize: number): Promise<any> {
     const searchParams: Record<string, string> = {
         action: "query",
         titles: pageTitle,
@@ -88,7 +88,7 @@ export async function fetchImageUrl(pageTitle: string, thumbSize: number): Promi
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
  * @return Object
  */
-export async function fetchInfoBox(pageTitle: string): Promise<Object> {
+export async function fetchInfoBox(pageTitle: string): Promise<any> {
     const searchParams: Record<string, string> = {
         action: "parse",
         page: pageTitle,

--- a/api/wikipediaSource.ts
+++ b/api/wikipediaSource.ts
@@ -1,0 +1,30 @@
+import {BASE_URL, ENDPOINT } from "~/api/apiConfig";
+
+/**
+ * Fetch and return the HTML of the given Wikipedia page.
+ * @param pageTitle the title of the Wikipedia page, must be first-capitalized
+ * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
+ */
+async function fetchHTMLPage(pageTitle: string): Promise<string> {
+    const searchParams = {
+        action: "parse",
+        format: "json",
+        prop: "text",
+        page: pageTitle
+    }
+
+    const queryParams: URLSearchParams = new URLSearchParams(searchParams);
+    const url: string = BASE_URL + ENDPOINT + queryParams
+
+    try {
+        const response: Response = await fetch(url);
+        const data = await response.json();
+        return data.parse.text
+    } catch (error) {
+        console.error('Error fetching page:', error);
+        throw error;
+    }
+}
+
+
+export { fetchHTMLPage }

--- a/model/GameModel.ts
+++ b/model/GameModel.ts
@@ -1,5 +1,6 @@
 import {resolvePromise} from "./resolvePromise.js";
 import {HintList, Hint} from "~/model/HintList";
+import {fetchIntro} from "~/api/wikipediaSource";
 
 
 export class GameModel {
@@ -24,7 +25,7 @@ export class GameModel {
      */
     constructor(name: string) {
         this._name = name;
-        resolvePromise(this.dummyPromise(), this._promiseState); //TODO: change the promise to a call to the api
+        resolvePromise(fetchIntro('Albert_Einstein'), this._promiseState);
         //TODO : initiate hints with parsing instead
         this._hints.birth.value = new Date(1879,2, 14);
         this._hints.death.value = new Date(1955,3, 18);
@@ -37,13 +38,6 @@ export class GameModel {
             " reshaping of the scientific understanding of nature that modern physics accomplished in the first decades of " +
             "the twentieth century theory..."
         this._imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Albert_Einstein_1947.jpg/440px-Albert_Einstein_1947.jpg";
-    }
-
-    //TODO: remove this method, needed only for testing purposes while api promises are not implemented
-    async dummyPromise() : Promise <any> {
-        await new Promise(resolve => setTimeout(resolve, 2000));
-        return fetch('https://jsonplaceholder.typicode.com/todos/1')
-            .then(response => response.json());
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "@iconify-json/simple-icons": "^1.1.95",
     "@nuxt/ui": "^2.14.2",
-    "nuxt": "^3.10.3"
+    "@types/infobox-parser": "^3.3.4",
+    "infobox-parser": "^3.6.4",
+    "nuxt": "^3.10.3",
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,5 +8,12 @@
       Go to example
     </ULink>
   </div>
-
 </template>
+
+<script lang="ts">
+import { fetchIntro, fetchImageUrl } from "~/api/wikipediaSource";
+const s : string = await fetchIntro("Jupiter");
+console.log(s)
+const url : string = await fetchImageUrl("Jupiter", 100);
+console.log(url)
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,17 +3,30 @@
     Home
   </div>
   <div class="font-medium text-blue-600 dark:text-blue-500 hover:underline">
-    <ULink
-        to="/example">
-      Go to example
-    </ULink>
+    <ULink to="/example">Go to example</ULink>
   </div>
+  <form @submit.prevent="getData">
+    <label for="name" class="mr-4">Enter Name</label>
+    <input type="text" id="name" v-model="selectedName" placeholder="Enter name" class="mr-4">
+    <button type="submit">Get Data</button>
+  </form>
+  <UCard class="m-4">{{ intro }}</UCard>
+  <img alt="profile picture" :src="imageUrl" v-if="imageUrl" class="m-4"/>
+  <UCard class="m-4">{{ infoBox }}</UCard>
 </template>
 
-<script lang="ts">
-import { fetchIntro, fetchImageUrl } from "~/api/wikipediaSource";
-const s : string = await fetchIntro("Jupiter");
-console.log(s)
-const url : string = await fetchImageUrl("Jupiter", 100);
-console.log(url)
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { fetchIntro, fetchImageUrl, fetchInfoBox } from "~/api/wikipediaSource";
+
+const selectedName = ref("Albert_Einstein");
+const intro = ref("");
+const imageUrl = ref("");
+const infoBox = ref("");
+
+const getData = async () => {
+  intro.value = await fetchIntro(selectedName.value);
+  imageUrl.value = await fetchImageUrl(selectedName.value, 100);
+  infoBox.value = await fetchInfoBox(selectedName.value);
+}
 </script>


### PR DESCRIPTION
This PR provides a small module to talk with the [MediaWiki Action API](https://en.wikipedia.org/w/api.php?), so as to retrieve wikipedia pages and more particularly their introduction text content and main picture. This module is located in `/api/wikipediaSource.ts`.

The MediaWiki Action API uses search parameters encoded in the URL (`<base_url>/<endpoint>?<param1>:<value1>&<param2>:<value2>`). I figured out to use the following parameters. 

**To retrieve HTML content of the page**
+ `action=query`, `titles={page_title}`, `format=json` are all standard MediaWiki API parameters
+ `prop=extracts` makes us have plain-text of limited HTML of the given page
+ `exintro` limits response to content before first section
+ `explaintext` returns extract as plain text instead of limited HTML

This gives us the following URL : `https://en.wikipedia.org/w/api.php?action=query&titles={page_title}&format=json&prop=extracts&exintro&explaintext`

**To retrieve the main image of the page**
+ `action=query`, `titles={page_title}`, `format=json` are all standard MediaWiki API parameters
+ `prop=pageimages` makes us have info about images on the page
+ `piprop=thumbnail` makes us retrieve the thumbnail instead of the original so as to have control over size
+ `pithumbsize={size}` makes us control the width in pixels we want for our image

This gives us the following URL :  `https://en.wikipedia.org/w/api.php?action=query&titles={page_title}&format=json&prop=pageimages&piprop=thumbnail&pithumbsize={size}`. 

There are two separate methods for retrieving both introduction content in plain text and main picture. 

Closes #3.