### PR TITLE
Parse hints from fetched infobox

### DIFF
--- a/api/wikipediaParser.ts
+++ b/api/wikipediaParser.ts
@@ -1,0 +1,24 @@
+import { HintList } from "~/model/HintList";
+
+export function parseHints (infoBox: any): HintList {
+
+    let birth: Date | undefined;
+    let ageOrDeath: Date | number | undefined
+    let occupation: string | undefined
+
+    if (infoBox.hasOwnProperty('birthDate')) {
+        birth = new Date(infoBox['birthDate']['date'])
+        ageOrDeath = infoBox['birthDate']['age']
+    }
+
+
+    if (infoBox.hasOwnProperty('deathDate')) {
+        ageOrDeath = infoBox['deathDate']['date']
+    }
+
+    if (infoBox.hasOwnProperty('occupation')) {
+        occupation = infoBox['occupation'][0]
+    }
+
+    return new HintList(birth, ageOrDeath, occupation, "", "", "");
+}

--- a/api/wikipediaSource.ts
+++ b/api/wikipediaSource.ts
@@ -1,4 +1,5 @@
 import parse from 'infobox-parser'
+import {options} from "kolorist";
 
 const BASE_URL: string = "https://en.wikipedia.org"
 const ENDPOINT: string = "/w/api.php?"
@@ -9,7 +10,7 @@ const ENDPOINT: string = "/w/api.php?"
  * Uses the MediaWiki Action API.
  * @param pageTitle the title of the Wikipedia page, must be first-capitalized
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
- * @return string
+ * @return Promise<string> - the introduction of the Wikipedia page as plain text
  */
 export async function fetchIntro(pageTitle: string): Promise<any> {
     const searchParams: Record<string, string> = {
@@ -47,7 +48,7 @@ export async function fetchIntro(pageTitle: string): Promise<any> {
  * @param pageTitle the title of the Wikipedia page, must be first-capitalized
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
  * @param thumbSize the width in pixels of the wanted thumbnail
- * @return string
+ * @return Promise<string> - the URL of the main image of the Wikipedia page
  */
 export async function fetchImageUrl(pageTitle: string, thumbSize: number): Promise<any> {
     const searchParams: Record<string, string> = {
@@ -86,7 +87,7 @@ export async function fetchImageUrl(pageTitle: string, thumbSize: number): Promi
  * Uses the MediaWiki Action API and the external library 'infobox-parser'.
  * @param pageTitle the title of the Wikipedia page, must be first-capitalized
  * words (except for name particles) separated by '_', for instance "Leonardo_da_Vinci"
- * @return Object
+ * @return Promise<Object> - the infobox as a JSON object
  */
 export async function fetchInfoBox(pageTitle: string): Promise<any> {
     const searchParams: Record<string, string> = {
@@ -106,7 +107,7 @@ export async function fetchInfoBox(pageTitle: string): Promise<any> {
         .then(data => {
             if ('parse' in data && 'wikitext' in data.parse) {
                 const wikitext: string = data.parse.wikitext["*"]
-                return parse(wikitext).general
+                return parse(wikitext, {simplifyDataValues: false}).general
             }
             throw new Error(`Infobox for page ${pageTitle} was not found.`)
         })

--- a/model/GameModel.ts
+++ b/model/GameModel.ts
@@ -1,14 +1,20 @@
-import {resolvePromise} from "./resolvePromise.js";
-import {HintList, Hint} from "~/model/HintList";
-import {fetchIntro} from "~/api/wikipediaSource";
+import { resolvePromise } from "~/model/resolvePromise";
+import type { PromiseState } from "~/model/resolvePromise";
+import { HintList } from "~/model/HintList";
+import { fetchIntro, fetchImageUrl } from "~/api/wikipediaSource";
+import { parseHints } from "~/api/wikipediaParser";
 
-
+/**
+ * This class represents the model of the game. It contains all the information needed to play the game.
+ * These elements are the name of the celebrity, the URL of an image of the celebrity, the hint list,
+ * the blur level, the current hint level,
+ */
 export class GameModel {
 
-    //celebrity information
+    // Celebrity information
     private _name: string;
-    private _imageUrl: string = '';
-    private _hints : HintList = new HintList();
+    private _imageUrl: string ;
+    private _hints : HintList ;
 
     //game information
     private _blur: number = 4;
@@ -16,7 +22,7 @@ export class GameModel {
     private _nbGuesses = 0;
     private _curGuess : string = '';
     private _prevGuesses : string[] = [];
-    private _promiseState: any = {};
+    private _promiseState: PromiseState = { data: null, promise: null, error: null };
     private _end: boolean = false;
     private _win: boolean = false;
 
@@ -25,18 +31,10 @@ export class GameModel {
      */
     constructor(name: string) {
         this._name = name;
-        resolvePromise(fetchIntro('Albert_Einstein'), this._promiseState);
         //TODO : initiate hints with parsing instead
-        this._hints.birth.value = new Date(1879,2, 14);
-        this._hints.death.value = new Date(1955,3, 18);
-        this._hints.occupation.value = "Physicist";
-        this._hints.citizenship.value = "Switzerland";
-        this._hints.initials.value = "A. E."
-        this._hints.paragraph1.value = "... was a German-born theoretical physicist who is widely held to be one of the " +
-            "greatest and most influential scientists of all time. Best known for developing the theory of relativity," +
-            " ... also made important contributions to quantum mechanics, and was thus a central figure in the revolutionary" +
-            " reshaping of the scientific understanding of nature that modern physics accomplished in the first decades of " +
-            "the twentieth century theory..."
+        resolvePromise(fetchIntro('Albert Einstein'), this._promiseState);
+        this._hints = parseHints(this._promiseState);
+        resolvePromise(fetchImageUrl('Albert Einstein', 100), this._promiseState);
         this._imageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Albert_Einstein_1947.jpg/440px-Albert_Einstein_1947.jpg";
     }
 

--- a/model/HintList.ts
+++ b/model/HintList.ts
@@ -1,33 +1,53 @@
-
-
+/**
+ * This class represents a list of hints necessary for one game. It contains 6 hints, each of them being of type `Hint`.
+ * The hints are the birthdate, the death date, the occupation, the citizenship, the initials and the first paragraph
+ * of the Wikipedia page of the celebrity.
+ */
 export class HintList {
-    birth: Hint<Date> = new Hint(1,  true);
-    death : Hint<Date> = new Hint(1);
-    occupation : Hint<string>= new Hint(1);
-    citizenship : Hint<string> = new Hint(1);
-    initials : Hint<string> = new Hint(2);
-    paragraph1 : Hint<string> = new Hint (2);
+    birth: Hint<Date> ;
+    ageOrDeath : Hint<Date | number> ;
+    occupation : Hint<string> ;
+    citizenship : Hint<string> ;
+    initials : Hint<string> ;
+    paragraph : Hint<string> ;
+
+    constructor(
+        birth: Date | undefined ,
+        ageOrDeath: Date | number | undefined,
+        occupation: string | undefined,
+        citizenship: string | undefined,
+        initials: string | undefined,
+        paragraph: string | undefined
+    ){
+        this.birth = new Hint(1,  true, birth)
+        this.ageOrDeath = new Hint(1, true, ageOrDeath);
+        this.occupation = new Hint(1, true, occupation);
+        this.citizenship = new Hint(1, true, citizenship);
+        this.initials = new Hint(2, true, initials);
+        this.paragraph = new Hint(2, true, paragraph);
+    }
 
     toList() : Hint<any>[]{
-        return [this.birth, this.death, this.occupation, this.citizenship, this.initials, this.paragraph1] ;
+        return [this.birth, this.ageOrDeath, this.occupation, this.citizenship, this.initials, this.paragraph] ;
     }
 
 }
 
-
 /**
- * this class represents a hint, the value being the core of the hint
- * revealed tells us if the hint has been revealed yet while level gives us
- * the level corresponding to the hint (1 being a small hint and 3 a huge hint)
+ * This class represents a hint, with its value and additional information. Attributes are the following :
+ * `revealed` tells us if the hint has been revealed yet, `level` gives us the level corresponding to the
+ * hint (from 1 to 3) and `value` is the value of the hint (can be of any type).
+ * @param T - the type of the value of the hint
  */
 export class Hint <T> {
     private _level : number;
-    private _value : T | null = null;
+    private _value : T | null ;
     private _revealed : boolean;
 
-    constructor(level: number, revealed : boolean = false ) {
+    constructor(level: number, revealed : boolean = false, value : T | null = null) {
         this._level = level;
         this._revealed = revealed;
+        this._value = value;
     }
 
     get level() : number {

--- a/model/resolvePromise.ts
+++ b/model/resolvePromise.ts
@@ -1,11 +1,16 @@
+export type PromiseState = {
+    promise: Promise<any> | null,
+    data: any | null,
+    error: string | null
+}
+
 /**
- * @credits : comes from the tutorial
- * Saves promise results in a `state` object (typically held in the Model),
- * so that the results can be shown in the UI.
+ * @credits : comes from the tutorial of the course "Interaction Programming and the Dynamic Web" by KTH University.
+ * Saves promise results in a `state` object (typically held in the Model), so that the results can be shown in the UI.
  * @param prms : Promise promise to resolve
- * @param promiseState state object of the Model
+ * @param promiseState : PromiseState state object of the Model
  */
-export function resolvePromise(prms : Promise<any>, promiseState : any){
+export function resolvePromise(prms : Promise<any>, promiseState : PromiseState) : void{
 
     // Checks for null promise
     if(prms === null) return;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,6 +8,7 @@ const isOpen = ref(false)
 
 import { ref } from 'vue';
 import { fetchIntro, fetchImageUrl, fetchInfoBox } from "~/api/wikipediaSource";
+import { parseHints } from "~/api/wikipediaParser";
 
 const selectedName = ref("Albert_Einstein");
 const intro = ref("");
@@ -18,6 +19,8 @@ const getData = async () => {
   intro.value = await fetchIntro(selectedName.value);
   imageUrl.value = await fetchImageUrl(selectedName.value, 100);
   infoBox.value = await fetchInfoBox(selectedName.value);
+  parseHints(infoBox.value)
+  console.log(infoBox.value)
 }
 
 </script>

--- a/views/infoboxView.vue
+++ b/views/infoboxView.vue
@@ -3,8 +3,6 @@
 import { GameModel } from "~/model/GameModel";
 import { reactive } from "vue";
 
-
-
 export default {
   props: {
     model: {
@@ -61,7 +59,7 @@ export default {
       </div>
     </template>
     <div class="flex flex-col items-center justify-center">
-      <div class="text-2xl font-bold">
+      <!-- <div class="text-2xl font-bold">
         {{ model.name }}
       </div>
       <div class="text-lg">
@@ -80,8 +78,8 @@ export default {
         {{model.hints.initials.revealed ? model.hints.initials.value: "-"}}
       </div>
       <div class="text-lg">
-        {{model.hints.paragraph1.revealed ? model.hints.paragraph1.value: "-"}}
-      </div>
+        {{model.hints.paragraph.revealed ? model.hints.paragraph.value: "-"}}
+      </div>-->
     </div>
   </UCard>
 </template>


### PR DESCRIPTION
This PR adds ability to parse the Wkipedia infobox which is fetched by the module `api/wikipediaSource.ts` so as to initialize a new `HintList` when a new `GameModel` is created when launching a game. The parsed hints are `birthDate`, `deathDate` (or `age` if personality is still alive), `occupation`, `citizenship`, `initials` and `paragraph`, which corresponds to the first section of the corresponding Wikipedia page. 
- [x] ` birthDate`
- [x] `deathDate` or `age`
- [ ] `occupation`
- [ ] `citizenship`
- [ ] `initials`
- [ ] `paragraph`