### PR TITLE
Login code from app.vue to presenter + UModal warning fix

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,6 +1,10 @@
 export default defineAppConfig({
     ui: {
         primary: 'amber',
-        gray: 'zinc'
+        gray: 'zinc',
+        notifications: {
+            // Show toasts at the top right of the screen
+            position: 'top-0 bottom-auto'
+        }
     }
 })

--- a/app.vue
+++ b/app.vue
@@ -2,94 +2,15 @@
     lang="ts"
     setup>
 import { UserModel } from './model/UserModel';
-import { initialiseFirebase } from './model/FirebaseModel';
-import { signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, type UserCredential } from 'firebase/auth'
-import { saveUserToFirebase, readUserFromFirebase } from '~/model/FirebaseModel';
-import LoginView from "~/views/LoginView.vue";
-import SignupView from "~/views/SignupView.vue";
+import LoginSignupPresenter from "~/presenters/LoginSignupPresenter.vue";
 
 const colorMode = useColorMode()
-const isErrorModalOpen = ref(false)
 const isDark = computed({
   get: () => colorMode.value === 'dark',
   set: () => colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
 })
 
 const userModel: any = reactive(new UserModel())
-
-initialiseFirebase()
-
-const isLogInOpen = ref(false)
-const errorMessage = ref('')
-
-const auth = useFirebaseAuth()!
-const user = useCurrentUser()
-
-const isUserLoggedIn = ref(false)
-
-// we don't need this watcher on server
-onMounted(() => {
-  watch(user, (user, prevUser) => {
-    if (prevUser && !user) {
-      // user logged out
-      console.log('Successfully logged out')
-      userModel.resetStats()
-      isUserLoggedIn.value = false
-    } else if (user) {
-      // user logged in
-      console.log('Successfully logged in')
-      readUserFromFirebase(userModel)
-      isUserLoggedIn.value = true
-    }
-  })
-})
-
-/**
- * Logs in the user
- *
- * @param username - The username used to log in
- * @param password - The password used to log in
- */
-function login(username: string, password: string) {
-  isLogInOpen.value = false
-  signInWithEmailAndPassword(auth, username, password)
-      .catch((reason) => {
-        console.error('Failed log in: ', reason)
-        errorMessage.value = 'Failed log in: '+ reason
-        isErrorModalOpen.value = true
-      })
-}
-
-/**
- * Signs up the user
- *
- * @param username - The username used to sign up
- * @param password - The password used to sign up
- */
-function signup(username: string, password: string) {
-  isLogInOpen.value = false
-  createUserWithEmailAndPassword(auth, username, password)
-      .then((userCredentials: UserCredential) => {
-        saveUserToFirebase(userModel, userCredentials.user?.uid);
-      })
-      .catch((reason) => {
-        console.error('Failed sign up: ', reason)
-        errorMessage.value = 'Failed sign up: '+reason
-        isErrorModalOpen.value = true
-      })
-}
-
-/**
- * Logs out the user
- */
-function logout() {
-  signOut(auth)
-      .catch((reason) => {
-        console.error('Failed log out: ', reason)
-        errorMessage.value = 'Failed log out: '+reason
-        isErrorModalOpen.value = true
-      })
-}
 
 </script>
 
@@ -126,29 +47,7 @@ function logout() {
           </a>
           <div class="flex justify-between items-center">
             <div class="p-3">
-              <UButton v-if="isUserLoggedIn" label="Log out" @click="logout"/>
-              <UButton v-else label="Log in" @click="isLogInOpen = true" />
-              <UModal v-model="isLogInOpen">
-                <div class="p-4">
-                  <div class="flex justify-center">
-                    <div class="w-60 ">
-                      <UTabs :items="[
-                        { key: 'login', label: 'Log in' },
-                        { key: 'signup', label: 'Sign up' }
-                        ]">
-                        <template #item="{ item }">
-                          <div v-if="item.key === 'login'">
-                            <LoginView @login-event="login"/>
-                          </div>
-                          <div v-else-if="item.key === 'signup'">
-                            <SignupView @signup-event="signup"/>
-                          </div>
-                        </template>
-                      </UTabs>
-                    </div>
-                  </div>
-                </div>
-              </UModal>
+              <LoginSignupPresenter :userModel/>
             </div>
             <div class="p-3">
               <ClientOnly>
@@ -164,16 +63,13 @@ function logout() {
             </div>
           </div>
         </div>
-        <UModal v-model="isErrorModalOpen">
-          <div class="p-4">
-            <p>{{errorMessage}}</p>
-          </div>
-        </UModal>
       </template>
 
       <main>
         <NuxtPage :userModel/>
       </main>
+
+      <UNotifications />
 
     </UCard>
   </UContainer>

--- a/presenters/LoginSignupPresenter.vue
+++ b/presenters/LoginSignupPresenter.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+
+import { UserModel } from "~/model/UserModel";
+import LoginView from "~/views/LoginView.vue";
+import { initialiseFirebase } from '~/model/FirebaseModel';
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, type UserCredential } from 'firebase/auth'
+import { saveUserToFirebase, readUserFromFirebase } from '~/model/FirebaseModel';
+import SignupView from "~/views/SignupView.vue";
+
+const props = defineProps({
+  userModel: {
+      type: UserModel,
+      required: true,
+  },
+})
+
+const toast = useToast()
+
+initialiseFirebase()
+
+const isLogInOpen = ref(false)
+
+const auth = useFirebaseAuth()!
+const user = useCurrentUser()
+
+const isUserLoggedIn = ref(false)
+
+// we don't need this watcher on server
+onMounted(() => {
+  watch(user, (user, prevUser) => {
+    if (prevUser && !user) {
+      // user logged out      
+      props.userModel.resetStats()
+      isUserLoggedIn.value = false
+    } else if (user) {
+      // user logged in
+      readUserFromFirebase(props.userModel)
+      isUserLoggedIn.value = true
+    }
+  })
+})
+
+
+/**
+ * Displays an error notification
+ *
+ * @param description - The description of the error
+ */
+function displayErrorNotification(description: string) {
+  toast.add({ title: 'Error', description: description, icon: 'i-heroicons-x-circle', color:"red"})
+}
+
+/**
+ * Logs in the user
+ *
+ * @param username - The username used to log in
+ * @param password - The password used to log in
+ */
+function login(username: string, password: string) {
+  isLogInOpen.value = false
+  signInWithEmailAndPassword(auth, username, password)
+      .catch((reason) => {
+        console.error('Failed log in: ', reason)
+        displayErrorNotification('Failed log in '+reason)
+      })
+}
+
+/**
+ * Signs up the user
+ *
+ * @param username - The username used to sign up
+ * @param password - The password used to sign up
+ */
+function signup(username: string, password: string) {
+  isLogInOpen.value = false
+  createUserWithEmailAndPassword(auth, username, password)
+      .then((userCredentials: UserCredential) => {
+        saveUserToFirebase(props.userModel, userCredentials.user?.uid);
+      })
+      .catch((reason) => {
+        console.error('Failed sign up: ', reason)
+        displayErrorNotification('Failed sign up '+reason)
+      })
+}
+
+/**
+ * Logs out the user
+ */
+function logout() {
+  signOut(auth)
+      .catch((reason) => {
+        console.error('Failed log out: ', reason)
+        displayErrorNotification('Failed log out '+reason)
+      })
+}
+</script>
+
+<template>
+    <UButton v-if="isUserLoggedIn" label="Log out" @click="logout"/>
+    <UButton v-else label="Log in" @click="isLogInOpen = true" />
+    <UModal v-model="isLogInOpen">
+    <div class="p-4">
+        <div class="flex justify-center">
+            <div class="w-60 ">
+                <UTabs :items="[
+                { key: 'login', label: 'Log in' },
+                { key: 'signup', label: 'Sign up' }
+                ]">
+                <template #item="{ item }">
+                    <div v-if="item.key === 'login'">
+                    <LoginView @login-event="login"/>
+                    </div>
+                    <div v-else-if="item.key === 'signup'">
+                    <SignupView @signup-event="signup"/>
+                    </div>
+                </template>
+                </UTabs>
+            </div>
+        </div>
+    </div>
+    </UModal>
+</template>


### PR DESCRIPTION
To display login/signup errors to the user, I replaced the UModal with a toast (Notifications) to resolve the warning `There are no focusable elements inside the <FocusTrap />` caused by the multiple UModal elements used in this presenter.

Closes (#56)