### PR TITLE
Remove "Status" from hints 

### DIFF
--- a/api/WikipediaSource.ts
+++ b/api/WikipediaSource.ts
@@ -162,8 +162,6 @@ function parseWikitext(wikitext: string): {[key: string]: string} {
     if (match) {
         const [, deathYear, deathMonth, deathDay] = match;
         hints["Died"] = `${deathDay} ${months[parseInt(deathMonth)]} ${deathYear}`;
-    }else {
-        hints["Status"] = "Alive";
     }
 
     // Description

--- a/model/Hint.ts
+++ b/model/Hint.ts
@@ -22,19 +22,18 @@ export function hintListFromObject(obj: {[key: string]:  string}): Hint[] {
             compulsoryHints.push({label: key, level: compulsoryLabels[key], value: value, revealed: key === 'Born'})
         }
     })
-    return [...compulsoryHints, ...arbitraryHints.slice(0, 2)]
+    return [...compulsoryHints, ...arbitraryHints.slice(0, 3)]
 }
 
 export const compulsoryLabels: {[key: string]: number} = {
     'Born': 1,
-    'Died': 1,
-    'Status': 1,
     'Occupation': 1,
     'Citizenship': 1,
     'Initials': 3,
 }
 
 const arbitraryLabels: {[key: string]: number} = {
+    'Died': 1,
     'Spouses': 2,
     'Genres': 2,
     'Political party': 2,


### PR DESCRIPTION
This PR removes the hint stating whether celebrity is alive or not and put the death date as an arbitrary hint. 
Closes #61 