### PR TITLE
Remove double scrolls

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -8,19 +8,19 @@ const store: UserStore = useUserStore()
 
 <template>
   <Body class="bg-gray-50 dark:bg-gray-950">
-  <UContainer class="p-0 sm:py-5 h-screen">
+  <UContainer class="p-0 sm:py-5 sm:h-screen">
     <UCard
       :ui="{
         base: 'flex flex-col h-full',
         rounded: 'rounded-none sm:rounded-lg',
         body: {
-          base: 'h-full overflow-clip',
+          base: 'h-full sm:overflow-clip',
         }
       }">
       <template #header>
         <HeaderPresenter :userModel="store"/>
       </template>
-       <main class="flex h-full overflow-y-auto justify-center">
+       <main class="flex sm:h-full overflow-y-auto justify-center">
         <NuxtPage/>
       </main>
       <UNotifications />

--- a/pages/daily-challenge.vue
+++ b/pages/daily-challenge.vue
@@ -70,12 +70,12 @@ onMounted(async () => {
         </div>
         <div class="h-full flex flex-col w-5/6 p-2">
           <PlayAgainPresenter :dailyChallenge="true" :gameModel="gameStore"/>
-          <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="true"/>
+          <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="true" class="overflow-y-auto"/>
         </div>
       </div>
 
       <!-- FOR SMALL SCREENS-->
-      <div class="h-full flex flex-col gap-4 lg:hidden">
+      <div class="h-full flex flex-col gap-3 lg:hidden">
         <PlayAgainPresenter :daily-challenge="true" :gameModel="gameStore"/>
         <div class="flex justify-between gap-2 items-center px-2.5 sm:pl-1">
           <div>

--- a/pages/solo-mode.vue
+++ b/pages/solo-mode.vue
@@ -58,12 +58,12 @@ onMounted(async () => {
       </div>
       <div class="h-full flex flex-col w-5/6 p-2">
         <PlayAgainPresenter :dailyChallenge="false" :gameModel="gameStore"/>
-        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false"/>
+        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false" class="overflow-y-auto"/>
       </div>
     </div>
 
     <!-- FOR SMALL SCREENS-->
-    <div class="h-full flex flex-col gap-4 lg:hidden">
+    <div class="h-full flex flex-col gap-3 lg:hidden">
       <PlayAgainPresenter :daily-challenge="false" :gameModel="gameStore"/>
       <div class="flex justify-between gap-2 items-center px-2.5 sm:pl-1">
         <div>

--- a/presenters/GamePresenter.vue
+++ b/presenters/GamePresenter.vue
@@ -130,7 +130,7 @@ if(props.dailyChallenge) watch(props.gameModel.$state, updateCurrentGame)
 </script>
 
 <template>
-  <div v-if="ready">
+  <div v-if="ready" class="flex flex-col h-full">
     <SearchFieldView
         @new-name-set="selectedName => guessAndCheck(selectedName)"
         :over="gameModel.end" :name="gameModel.name" :alert="!validGuess"


### PR DESCRIPTION
On mobile, entirely remove the ability to scroll inside the game presenter : now only possible to scroll the whole page (including the header) to fix the bug.

This PR only solve a bug where there was a double scroll when the game was over and the "play again" alert shows up

Closes #141