### PR TITLE
Add animations when revealing paragraphs and unblurring the picture

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -20,7 +20,7 @@ const store: UserStore = useUserStore()
       <template #header>
         <HeaderPresenter :userModel="store"/>
       </template>
-       <main class="flex sm:h-full overflow-y-auto justify-center">
+       <main class="flex sm:h-full sm:overflow-y-auto justify-center">
         <NuxtPage/>
       </main>
       <UNotifications />

--- a/model/Hint.ts
+++ b/model/Hint.ts
@@ -1,5 +1,3 @@
-import { getRandom } from "~/utilities/Utils"
-
 /**
  * This interface represents a Hint for the game, and all its possible attributes.
  * Its purpose is to be extended with types that omit certain attributes.
@@ -104,6 +102,14 @@ export async function imagesOf(url: string): Promise<BlurHint[]> {
         })
     })
 
+    const urlBlur3 = await $fetch('/api/blur-image', {
+        method: 'POST',
+        body: JSON.stringify({
+            url: url,
+            blur: 0
+        })
+    })
+
     return [{
             url: urlBlur1,
             level: 0,
@@ -115,7 +121,7 @@ export async function imagesOf(url: string): Promise<BlurHint[]> {
             revealed: false
         },
         {
-            url: url,
+            url: urlBlur3,
             level: 3,
             revealed: false
         }]

--- a/pages/solo-mode.vue
+++ b/pages/solo-mode.vue
@@ -58,7 +58,7 @@ onMounted(async () => {
       </div>
       <div class="h-full flex flex-col w-5/6 p-2">
         <PlayAgainPresenter :dailyChallenge="false" :gameModel="gameStore"/>
-        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false" class="overflow-y-auto"/>
+        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false" class="overflow-y-auto" size="big"/>
       </div>
     </div>
 
@@ -86,7 +86,7 @@ onMounted(async () => {
         </UCard>
       </USlideover>
       <div class="h-full overflow-y-auto">
-        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false"/>
+        <GamePresenter :userModel="userStore" :gameModel="gameStore" :dailyChallenge="false" size="small"/>
       </div>
     </div>
   </div>

--- a/presenters/GamePresenter.vue
+++ b/presenters/GamePresenter.vue
@@ -29,6 +29,10 @@ const props = defineProps({
     type: Boolean,
     required: true,
   },
+  size: {
+    type: String,
+    required: true,
+  }
 })
 
 // Constants
@@ -139,7 +143,7 @@ if(props.dailyChallenge) watch(props.gameModel.$state, updateCurrentGame)
       <GameCenterView
           :intro="gameModel.intro" :over="gameModel.end" :name="gameModel.name" :win = "gameModel.win"
           :first-sentence="gameModel.firstSentence" :fields = "gameModel.infobox" :imageUrl="gameModel.imageUrl"
-          :buttonLink="baseString + gameModel.name"
+          :buttonLink="baseString + gameModel.name" :size="size"
       />
     </div>
   </div>

--- a/server/api/blur-image.ts
+++ b/server/api/blur-image.ts
@@ -39,9 +39,11 @@ export default defineEventHandler(async (event) => {
     const blob = await response.blob()
     const image = await Jimp.read(Buffer.from(await blob.arrayBuffer()))
 
-    if (blur >= 0) {
+    if (blur > 0) {
         image.blur(blur)
     }
 
     return await image.getBase64Async(Jimp.MIME_JPEG)
+
+    // return `<img src="${await image.getBase64Async(Jimp.MIME_JPEG)}" />`
 })

--- a/views/GameCenterView.vue
+++ b/views/GameCenterView.vue
@@ -51,11 +51,20 @@ function format(str: string) : string {
   return blurHTML(removeNameOccurrences(str, props.name))
 }
 
+function scrollToParagraph(index: number, over: boolean) {
+  if (over) return
+  const element = document.getElementById(`p${index}`)
+  if (element) {
+    console.log("Scrolling to paragraph", index)
+    element.scrollIntoView({ behavior: "smooth", block: "center" })
+  }
+}
+
 </script>
 
 <template>
   <div class="p-2 text-justify">
-    <div class="p-1 sm:ml-4 sm:float-right overflow-hidden">
+    <div class="p-1 sm:ml-4 sm:float-right">
       <InfoboxView
           :fields = "fields" :imageUrl="imageUrl"
           :over="over" :buttonLink="buttonLink"
@@ -64,10 +73,36 @@ function format(str: string) : string {
 
     <span v-if="over">{{ firstSentence }}</span>
     <div v-for="(paragraph, index) in intro" :key="index" class="inline">
-      <span v-if="paragraph.revealed && !over" v-html="format(paragraph.value)"></span>
-      <span v-else-if="over">{{ paragraph.value }}</span>
-      <span v-else class="blur-sm">{{ encrypted[index] }}</span>
+      <Transition
+          name="reveal"
+          @enter="scrollToParagraph(index, over)"
+      >
+        <span v-if="paragraph.revealed && !over" v-html="format(paragraph.value)" :id="`p${index}`"></span>
+        <span v-else-if="over" :id="`p${index}`">{{ paragraph.value }}</span>
+        <span v-else class="blur-sm" :id="`p${index}`">{{ encrypted[index] }}</span>
+      </Transition>
     </div>
   </div>
 </template>
+
+<style scoped>
+  .reveal-enter-active {
+    animation: scale-text 1.2s
+  }
+
+  @keyframes scale-text {
+    0% {
+      transform: scale(1)
+    }
+
+    50% {
+      transform: scale(1.3);
+      color: rgb(245, 158, 12)
+    }
+
+    100% {
+      transform: scale(1)
+    }
+  }
+</style>
 

--- a/views/GameCenterView.vue
+++ b/views/GameCenterView.vue
@@ -92,21 +92,12 @@ function scrollToParagraph(index: number, size: string, over: boolean) {
 
 <style scoped>
   .reveal-enter-active {
-    animation: scale-text 1.2s
+    animation: fade-color 1.2s
   }
 
-  @keyframes scale-text {
-    0% {
-      transform: scale(1)
-    }
-
+  @keyframes fade-color {
     50% {
-      transform: scale(1.3);
       color: rgb(245, 158, 12)
-    }
-
-    100% {
-      transform: scale(1)
     }
   }
 </style>

--- a/views/GameCenterView.vue
+++ b/views/GameCenterView.vue
@@ -39,6 +39,10 @@ const props = defineProps( {
       type : String,
       required: true,
     },
+    size: {
+      type: String,
+      required: true,
+    }
 })
 
 // Constants
@@ -51,12 +55,13 @@ function format(str: string) : string {
   return blurHTML(removeNameOccurrences(str, props.name))
 }
 
-function scrollToParagraph(index: number, over: boolean) {
+function scrollToParagraph(index: number, size: string, over: boolean) {
   if (over) return
-  const element = document.getElementById(`p${index}`)
+  const element = document.getElementById(`p-${size}-${index}`)
   if (element) {
-    console.log("Scrolling to paragraph", index)
-    element.scrollIntoView({ behavior: "smooth", block: "center" })
+    if (element.checkVisibility()) {
+      element.scrollIntoView({ behavior: "smooth", block: "center"})
+    }
   }
 }
 
@@ -75,11 +80,11 @@ function scrollToParagraph(index: number, over: boolean) {
     <div v-for="(paragraph, index) in intro" :key="index" class="inline">
       <Transition
           name="reveal"
-          @enter="scrollToParagraph(index, over)"
+          @enter="scrollToParagraph(index, size, over)"
       >
-        <span v-if="paragraph.revealed && !over" v-html="format(paragraph.value)" :id="`p${index}`"></span>
-        <span v-else-if="over" :id="`p${index}`">{{ paragraph.value }}</span>
-        <span v-else class="blur-sm" :id="`p${index}`">{{ encrypted[index] }}</span>
+        <span v-if="paragraph.revealed && !over" v-html="format(paragraph.value)" :id="`p-${size}-${index}`"></span>
+        <span v-else-if="over" :id="`p-${size}-${index}`">{{ paragraph.value }}</span>
+        <span v-else class="blur-sm" :id="`p-${size}-${index}`">{{ encrypted[index] }}</span>
       </Transition>
     </div>
   </div>

--- a/views/InfoboxView.vue
+++ b/views/InfoboxView.vue
@@ -1,3 +1,4 @@
+<!--suppress ALL -->
 <script setup lang="ts">
 import { type InfoboxHint, compulsoryLabels } from "~/model/Hint"
 import { capitalize } from "~/utilities/Utils"
@@ -28,7 +29,9 @@ const props = defineProps( {
     <UCard class="flex flex-col items-center justify-center" :ui="{header: {padding:''}}">
       <template #header>
         <div class="flex flex-col items-center justify-center my-5">
-          <img :src="imageUrl" alt="image" class="w-40 object-cover pointer-events-none rounded-md rounded-b-md shadow-md"/>
+          <transition name="scale-up" mode="out-in">
+            <img :src="imageUrl" :key="imageUrl" alt="image" class="w-40 object-cover pointer-events-none rounded-md rounded-b-md shadow-md"/>
+          </transition>
         </div>
       </template>
       <div class="flex flex-col items-center justify-center py-5">
@@ -61,12 +64,13 @@ const props = defineProps( {
   </div>
 </template>
 
+
 <style scoped>
 .v-enter-active {
-  animation: scale 1.5s 
+  animation: scale-text 1.2s
 }
 
-@keyframes scale {
+@keyframes scale-text {
   0% {
     transform: scale(1)
   }
@@ -79,6 +83,19 @@ const props = defineProps( {
   100% {
     transform: scale(1)
   }
+}
+
+.scale-up-enter-active {
+  transition: all 1.2s;
+}
+
+.scale-up-leave-active {
+  transition: all 0.6s;
+}
+
+.scale-up-enter-from, .scale-up-leave-to {
+  transform: scale(1.05);
+  box-shadow: 0 0 15px 6px rgb(245, 158, 12, 0.9);
 }
 
 </style>

--- a/views/InfoboxView.vue
+++ b/views/InfoboxView.vue
@@ -58,7 +58,7 @@ const props = defineProps( {
         </table>
       </div>
       <div v-if="over" style="display: flex; justify-content: center">
-        <UButton :to="buttonLink" size="lg">Learn more</UButton>
+        <UButton :to="buttonLink" target="_blank" size="lg" color="gray" icon="i-heroicons-document-magnifying-glass">Learn more</UButton>
       </div>
     </UCard>
   </div>

--- a/views/PlayAgainView.vue
+++ b/views/PlayAgainView.vue
@@ -32,7 +32,7 @@ const emit = defineEmits(['new-game'])
           v-if="!challenge"
           :actions="[
             { variant: 'solid', color: 'primary', label: 'PLAY AGAIN', click: () => { emit('new-game') }},
-            { variant: 'soft', color: 'primary', label: 'DAILY CHALLENGE', click: () => { navigateTo('/daily-challenge') }},
+            { variant: 'outline', color: 'primary', label: 'DAILY CHALLENGE', click: () => { navigateTo('/daily-challenge') }},
           ]"
           title="More ?"
           :ui="{


### PR DESCRIPTION
This PR add animations when revealing the hints 

- [x] Infobox : It was done in a previous PR
- [x] Paragraphs :
Add a scroll to the paragraph revealed and add a small animation similar to the one done in the infobox. Below you can find an example of what it looks like on mobile (mobile is the most affected by this change because we could not see the paragraphs on the screen)
- [x] Picture unblur : 
Add a small scaling and an orange shadow behind the picture


https://github.com/roxannecvl/whokipedia/assets/91327170/0cf555b8-7680-4313-a9f0-895e74313274