### PR TITLE
Fix inconsistency in scrolling to paragraphs

### DIFF
--- a/views/GameCenterView.vue
+++ b/views/GameCenterView.vue
@@ -67,7 +67,9 @@ function scrollToParagraph(index: number, size: string, over: boolean): void {
   if (over) return
   const element = document.getElementById(`p-${size}-${index}`)
   if (element) {
-    if (element.checkVisibility()) {
+    // According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+    // offsetParent is null if the element or any of its parents is display: none
+    if (element.offsetParent) {
       element.scrollIntoView({ behavior: "smooth", block: "center"})
     }
   }


### PR DESCRIPTION
Replace the method [`checkVisibility()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) which is supported only on recent versions of most browsers by [`HTMLElement.offsetParent`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent) which is supported everywhere and basically does the same thing