### PR TITLE
Add username to statistics modal

### DIFF
--- a/presenters/HeaderPresenter.vue
+++ b/presenters/HeaderPresenter.vue
@@ -109,6 +109,6 @@ function updateLeaderboard(): void {
       :gamesPlayedSV="userModel.gamesPlayed"
       :timedStatsSV="userModel.timedStats"
       :gamesLV="usersData"
-      :usernameLV="userModel.username"
+      :usernameLVSV="userModel.username"
   />
 </template>

--- a/views/HeaderView.vue
+++ b/views/HeaderView.vue
@@ -43,7 +43,7 @@ const props = defineProps({
     type: Array<LeaderboardData>,
     required: true,
   },
-  usernameLV: {
+  usernameLVSV: {
     type: String,
     required: true,
   }
@@ -85,7 +85,7 @@ const logoPath = '/img/logo-primary-filled.svg'
       <LeaderboardView
           @update-leaderboard ="emit('update-leaderboard-bis')"
           :games="gamesLV"
-          :username="usernameLV"
+          :username="usernameLVSV"
       />
       <StatisticsView
           :current-streak="currentStreakSV"
@@ -95,6 +95,7 @@ const logoPath = '/img/logo-primary-filled.svg'
           :win-rate="winRateSV"
           :games-played="gamesPlayedSV"
           :timed-stats="timedStatsSV"
+          :username="usernameLVSV"
       />
       <LoginSignupView
         @login-event-bis="(email, password) => emit('login-event-tris', email, password)"

--- a/views/StatisticsView.vue
+++ b/views/StatisticsView.vue
@@ -33,6 +33,10 @@ const props = defineProps({
     type: Array<TimedStat>,
     required: true
   },
+  username: {
+    type: String,
+    required: true
+  }
 })
 
 // Refs
@@ -55,7 +59,7 @@ const maxStreakColor = computed(() => getColor(props.maxStreak))
     <UCard :ui="{ ring: '' }">
       <template #header>
         <div class="flex items-center justify-between">
-          <h3 class="text-2xl font-semibold text-gray-900 dark:text-white">Statistics</h3>
+          <h3 class="text-2xl font-semibold text-gray-900 dark:text-white">Well done, <span class="text-primary">{{ username }}</span> !</h3>
           <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark-20-solid" @click="isStatOpen = false" />
         </div>
       </template>


### PR DESCRIPTION
This PR adds a message "Well done, `{{ username }}` !" to the statistics modal so as to display username somewhere on the page. 

<img width="1470" alt="Capture d’écran 2024-04-29 à 16 33 39" src="https://github.com/roxannecvl/whokipedia/assets/66010389/31adf658-8f7c-4254-bd06-26eddd4cd9f9">
<img width="1470" alt="Capture d’écran 2024-04-29 à 16 33 48" src="https://github.com/roxannecvl/whokipedia/assets/66010389/13ad1cc7-7537-48bd-92e1-56d1276d63e1">
<img width="1470" alt="Capture d’écran 2024-04-29 à 16 33 54" src="https://github.com/roxannecvl/whokipedia/assets/66010389/de817eef-251f-4494-ac29-7b366b0962f0">
<img width="1470" alt="Capture d’écran 2024-04-29 à 16 34 06" src="https://github.com/roxannecvl/whokipedia/assets/66010389/20adbc4f-cbf8-4da5-85db-8d1c7d4b98df">
Closes #140 